### PR TITLE
Add `strict_max_version`

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -7,7 +7,8 @@
   "applications": {
     "gecko": {
       "id": "full-address-column@lukasz.kosson.net",
-      "strict_min_version": "68.0a1"
+      "strict_min_version": "68.0a1",
+      "strict_max_version": "91.*"
     }
   },
   "experiment_apis": {


### PR DESCRIPTION
Add `strict_max_version` due to  Thunderbird Add-on gallery  validation tests updates