### PR TITLE
Use Services global variable if possible

### DIFF
--- a/src/customcol.js
+++ b/src/customcol.js
@@ -1,7 +1,9 @@
 // This Source Code Form is subject to the terms of the
 // GNU General Public License, version 3.0.
 var { AppConstants } = ChromeUtils.import("resource://gre/modules/AppConstants.jsm");
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+var Services = globalThis.Services || ChromeUtils.import(
+  "resource://gre/modules/Services.jsm"
+).Services;
 
 var MSG_VIEW_FLAG_DUMMY = 0x20000000;
 

--- a/src/experiments.js
+++ b/src/experiments.js
@@ -2,7 +2,9 @@
 // GNU General Public License, version 3.0.
 
 "use strict";
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+var Services = globalThis.Services || ChromeUtils.import(
+  "resource://gre/modules/Services.jsm"
+).Services;
 var { ExtensionSupport } = ChromeUtils.import('resource:///modules/ExtensionSupport.jsm');
 var { ExtensionParent } = ChromeUtils.import('resource://gre/modules/ExtensionParent.jsm');
 


### PR DESCRIPTION
Services.jsm is planned to be removed in Firefox 117 cycle in https://bugzilla.mozilla.org/show_bug.cgi?id=1780695 . Services global variable is available in WebExtensions experiments API global from version 88 https://bugzilla.mozilla.org/show_bug.cgi?id=1698158 , and experiments code doesn't have to import Services.jsm for recent versions.