### PR TITLE
Version 1.2.0. Added feature #18: new columns "sender domain" and "re…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 Full address column
 ===================
 
-This add-on adds two new columns called "Sender (@)" and "Recipient (@)" in 
-message list containing full, raw addresses of sender and recipient instead 
-of just names like in default columns.
+This add-on adds four new columns called "Sender (@)", "Sender Domain (@)",
+"Recipients (@)" and "Recipients Domains (@)" in message list containing full,
+raw addresses of sender and recipient as well as their domains instead of just
+names like in the default columns.
 
-This add-on is reimplementation of "Show address only" which stopped working 
-in Thunderbird 78. This add-on source was originally based on "SFreq" by 
-Jorg K. Version working with Supernova update is based on examples provided by 
+This add-on is reimplementation of "Show address only" which stopped working
+in Thunderbird 78. This add-on source was originally based on "SFreq" by
+Jorg K. Version working with Supernova update is based on examples provided by
 John Bieling.

--- a/src/README.txt
+++ b/src/README.txt
@@ -1,11 +1,12 @@
 Full address column
 ===================
 
-This add-on adds two new columns called "Sender (@)" and "Recipient (@)" in 
-message list containing full, raw addresses of sender and recipient instead 
-of just names like in default columns.
+This add-on adds four new columns called "Sender (@)", "Sender Domain (@)",
+"Recipients (@)" and "Recipients Domains (@)" in message list containing full,
+raw addresses of sender and recipient as well as their domains instead of just
+names like in the default columns.
 
-This add-on is reimplementation of "Show address only" which stopped working 
-in Thunderbird 78. This add-on source was originally based on "SFreq" by 
-Jorg K. Version working with Supernova update is based on examples provided by 
+This add-on is reimplementation of "Show address only" which stopped working
+in Thunderbird 78. This add-on source was originally based on "SFreq" by
+Jorg K. Version working with Supernova update is based on examples provided by
 John Bieling.

--- a/src/background.js
+++ b/src/background.js
@@ -1,2 +1,4 @@
 browser.customColumns.add("senderAddressColumn", "Sender (@)", "sender");
-browser.customColumns.add("recipientAddressColumn", "Recipient (@)", "recipient");
+browser.customColumns.add("senderDomainColumn", "Sender Domain (@)", "sender_domain");
+browser.customColumns.add("recipientsAddressesColumn", "Recipients (@)", "recipients");
+browser.customColumns.add("recipientsDomainsColumn", "Recipients Domains (@)", "recipients_domains");

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Full Address column",
-  "description": "Adds a full sender and recipient e-mail column to message list panel",
+  "description": "Adds sender and recipient full e-mail and domain columns to message list panel",
   "version": "1.1.2",
   "author": "Łukasz Kosson",
   "browser_specific_settings": {


### PR DESCRIPTION
…cipients domains", code refactoring

- kept version "1.1.2"
- domain columns initially not visible

I think you can easily check the initial column settings when you create a new folder in your mail account

