### PR TITLE
Column with reversed recipients domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@ Full address column
 ===================
 
 This add-on adds four new columns called "Sender (@)", "Sender Domain (@)",
-"Recipients (@)" and "Recipients Domains (@)" in message list containing full,
-raw addresses of sender and recipient as well as their domains instead of just
-names like in the default columns.
+"Sender Reverse Domain (@)", "Recipients (@)", "Recipients Domains (@)" and
+"Recipients Reverse Domains (@)" in message list containing full, raw addresses
+of sender and recipient as well as their domains and reserved domains instead
+of just names like in the default columns.
 
 This add-on is reimplementation of "Show address only" which stopped working
 in Thunderbird 78. This add-on source was originally based on "SFreq" by

--- a/src/README.txt
+++ b/src/README.txt
@@ -2,9 +2,10 @@ Full address column
 ===================
 
 This add-on adds four new columns called "Sender (@)", "Sender Domain (@)",
-"Recipients (@)" and "Recipients Domains (@)" in message list containing full,
-raw addresses of sender and recipient as well as their domains instead of just
-names like in the default columns.
+"Sender Reverse Domain (@)", "Recipients (@)", "Recipients Domains (@)" and
+"Recipients Reverse Domains (@)" in message list containing full, raw addresses
+of sender and recipient as well as their domains and reserved domains instead
+of just names like in the default columns.
 
 This add-on is reimplementation of "Show address only" which stopped working
 in Thunderbird 78. This add-on source was originally based on "SFreq" by

--- a/src/background.js
+++ b/src/background.js
@@ -3,3 +3,4 @@ browser.customColumns.add("senderDomainColumn", "Sender Domain (@)", "sender_dom
 browser.customColumns.add("senderReverseDomainColumn", "Sender Reverse Domain (@)", "sender_reverse_domain");
 browser.customColumns.add("recipientsAddressesColumn", "Recipients (@)", "recipients");
 browser.customColumns.add("recipientsDomainsColumn", "Recipients Domains (@)", "recipients_domains");
+browser.customColumns.add("recipientsReverseDomainsColumn", "Recipients Reverse Domains (@)", "recipients_reverse_domains");

--- a/src/background.js
+++ b/src/background.js
@@ -1,4 +1,5 @@
 browser.customColumns.add("senderAddressColumn", "Sender (@)", "sender");
 browser.customColumns.add("senderDomainColumn", "Sender Domain (@)", "sender_domain");
+browser.customColumns.add("senderReverseDomainColumn", "Sender Reverse Domain (@)", "sender_reverse_domain");
 browser.customColumns.add("recipientsAddressesColumn", "Recipients (@)", "recipients");
 browser.customColumns.add("recipientsDomainsColumn", "Recipients Domains (@)", "recipients_domains");

--- a/src/implementation.js
+++ b/src/implementation.js
@@ -16,6 +16,7 @@ const fn__string_to_addresses = mail_string => mail_string.replaceAll(/".*?"/g, 
 const fn__normalize_address = mail => mail.replace(/^.*?</, '').replace(/>.*$/, '').trim()
 
 const fn__address_to_domain = x => x.replace(/^.*@/, '')
+const fn__reverse_domain = x => x.split('.').reverse().join('.')
 
 const extract_unique_normalized_addresses = addresses_string => fn__deduplicate(fn__string_to_addresses(addresses_string).map(x => fn__normalize_address(x)))
 const extract_unique_domains = addresses_string => fn__deduplicate(extract_unique_normalized_addresses(addresses_string).map(x => fn__address_to_domain(x)))
@@ -40,7 +41,7 @@ var customColumns = class extends ExtensionCommon.ExtensionAPI {
             },
 
             sender_reverse_domain: function (message) {
-              return fn__address_to_domain(extract_unique_normalized_addresses(message.author)[0]).split('.').reverse().join('.');
+              return fn__reverse_domain(fn__address_to_domain(extract_unique_normalized_addresses(message.author)[0]));
             },
 
             recipients: function (message) {

--- a/src/implementation.js
+++ b/src/implementation.js
@@ -39,6 +39,10 @@ var customColumns = class extends ExtensionCommon.ExtensionAPI {
               return fn__address_to_domain(extract_unique_normalized_addresses(message.author)[0]);
             },
 
+            sender_reverse_domain: function (message) {
+              return fn__address_to_domain(extract_unique_normalized_addresses(message.author)[0]).split('.').reverse().join('.');
+            },
+
             recipients: function (message) {
               return extract_unique_normalized_addresses(message.recipients).join(', ')
             },

--- a/src/implementation.js
+++ b/src/implementation.js
@@ -51,6 +51,10 @@ var customColumns = class extends ExtensionCommon.ExtensionAPI {
             recipients_domains: function (message) {
               return extract_unique_domains(message.recipients).join(', ')
             },
+
+            recipients_reverse_domains: function (message) {
+              return extract_unique_domains(message.recipients).map(x => fn__reverse_domain(x)).join(', ')
+            },
           }
 
           ThreadPaneColumns.addCustomColumn(id, {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Full Address column",
-  "description": "Adds sender and recipient full e-mail and domain columns to message list panel",
+  "description": "Adds sender and recipient full e-mail, domain and reverse domain columns to message list panel",
   "version": "1.2.3",
   "author": "Łukasz Kosson",
   "browser_specific_settings": {


### PR DESCRIPTION
I guess if reversed order of sender's domains is a nice thing, the recipients deserve a similar column too.

Sorry for the mess of first four commits. I am somehow fucked up the branching at the right place. :(